### PR TITLE
meta-gateway: add crda into cube-gw image

### DIFF
--- a/recipes-core/images/cube-gw-gfx_0.1.bb
+++ b/recipes-core/images/cube-gw-gfx_0.1.bb
@@ -29,7 +29,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 
 # WiFi and Bluetooth
 IMAGE_INSTALL += "hostapd hostap-utils"
-IMAGE_INSTALL += "wireless-tools wpa-supplicant"
+IMAGE_INSTALL += "wireless-tools wpa-supplicant crda"
 IMAGE_INSTALL += "linux-firmware"
 IMAGE_INSTALL += "bluez5"
 

--- a/recipes-core/images/cube-gw_0.1.bb
+++ b/recipes-core/images/cube-gw_0.1.bb
@@ -28,7 +28,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 
 # WiFi and Bluetooth
 IMAGE_INSTALL += "hostapd hostap-utils"
-IMAGE_INSTALL += "wireless-tools wpa-supplicant"
+IMAGE_INSTALL += "wireless-tools wpa-supplicant crda"
 IMAGE_INSTALL += "linux-firmware"
 IMAGE_INSTALL += "bluez5"
 


### PR DESCRIPTION
Issue: LINPUL8-666

Add crda into images cube-gw and cube-gw-gfx to set country
regulatory for WIFI.

Signed-off-by: De Huo <De.Huo@windriver.com>