### PR TITLE
meta: drop ${COREBASE}/LICENSE references

### DIFF
--- a/recipes-core-luci/firewall/firewall_3.0.bb
+++ b/recipes-core-luci/firewall/firewall_3.0.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://git.openwrt.org/project/firewall3.git \
 "
 
 SRCREV = "a4d98aea373e04f3fdc3c492c1688ba52ce490a9"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/images/cube-gw-gfx_0.1.bb
+++ b/recipes-core/images/cube-gw-gfx_0.1.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "Launched from the essential image, this is a container image \
 HOMEPAGE = "http://www.windriver.com"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 

--- a/recipes-core/images/cube-gw_0.1.bb
+++ b/recipes-core/images/cube-gw_0.1.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "Launched from the essential image, this is a container image \
 HOMEPAGE = "http://www.windriver.com"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 


### PR DESCRIPTION
The top level LICENSE file is not actually a license, it refers
other licenses that are used by Bitbake and Meta-data. Relying
on this file could cause problems for recipes when this file
changes, which it is about to.

Signed-off-by: Ming Liu <ming.liu@windriver.com>