### PR TITLE
dnsmasq: replaces base_contains with bb.utils.contains

### DIFF
--- a/recipes-core-luci/dnsmasq/dnsmasq_2.7%.bbappend
+++ b/recipes-core-luci/dnsmasq/dnsmasq_2.7%.bbappend
@@ -34,7 +34,7 @@ do_install () {
         install -d ${D}${systemd_unitdir}/system
         install -m 0644 ${WORKDIR}/dnsmasq.service ${D}${systemd_unitdir}/system
 
-        if [ "${@base_contains('PACKAGECONFIG', 'dbus', 'dbus', '', d)}" != "" ]; then
+        if [ "${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'dbus', '', d)}" != "" ]; then
             install -d ${D}${sysconfdir}/dbus-1/system.d
             install -m 644 dbus/dnsmasq.conf ${D}${sysconfdir}/dbus-1/system.d/
         fi


### PR DESCRIPTION
'base_contains' is deprecated.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>