### PR TITLE
Update meta-gateway for newer oe-core

### DIFF
--- a/recipes-core-luci/netifd/files/0003-replace_is_error_helper_with_null_check.patch
+++ b/recipes-core-luci/netifd/files/0003-replace_is_error_helper_with_null_check.patch
@@ -1,0 +1,32 @@
+From d3a5df04bdcc039d900df49c8c608c1a91a976c7 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <ardeleanalex@gmail.com>
+Date: Fri, 8 Dec 2017 16:22:13 +0200
+Subject: [PATCH] handler: replace is_error() helper with NULL check
+
+The `is_error()` is just a macro that checks
+that object is NULL (which is considered an error
+in libjson-c terminology).
+
+Newer libjson-c versions have deprecated this.
+
+Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
+---
+ handler.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/handler.c b/handler.c
+index 0c4627f..a0b2a57 100644
+--- a/handler.c
++++ b/handler.c
+@@ -105,7 +105,7 @@ netifd_parse_script_handler(const char *name, script_dump_cb cb)
+ 			tok = json_tokener_new();
+ 
+ 		obj = json_tokener_parse_ex(tok, start, len);
+-		if (!is_error(obj)) {
++		if (obj) {
+ 			netifd_init_script_handler(name, obj, cb);
+ 			json_object_put(obj);
+ 			json_tokener_free(tok);
+-- 
+2.1.4
+

--- a/recipes-core-luci/netifd/netifd_git.bb
+++ b/recipes-core-luci/netifd/netifd_git.bb
@@ -23,6 +23,7 @@ SRC_URI = "git://git.openwrt.org/project/netifd.git;protocol=git \
             file://sbin/ifup \
             file://0001-Make-netifd-to-clean-resolv.conf.auto-when-link-down.patch \
             file://0002-system-linux-Fix-IFF_LOWER_UP-define.patch \
+            file://0003-replace_is_error_helper_with_null_check.patch \
             file://etc/hotplug.d/iface/00-netstate \
             file://etc/modem_cell_default \
             file://etc/config/network \

--- a/recipes-core/images/cube-gw-gfx_0.1.bb
+++ b/recipes-core/images/cube-gw-gfx_0.1.bb
@@ -28,7 +28,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   "
 
 # WiFi and Bluetooth
-IMAGE_INSTALL += "hostapd hostap-utils"
+IMAGE_INSTALL += "hostapd"
 IMAGE_INSTALL += "wireless-tools wpa-supplicant"
 IMAGE_INSTALL += "linux-firmware"
 IMAGE_INSTALL += "bluez5"

--- a/recipes-core/images/cube-gw_0.1.bb
+++ b/recipes-core/images/cube-gw_0.1.bb
@@ -27,7 +27,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   "
 
 # WiFi and Bluetooth
-IMAGE_INSTALL += "hostapd hostap-utils"
+IMAGE_INSTALL += "hostapd"
 IMAGE_INSTALL += "wireless-tools wpa-supplicant"
 IMAGE_INSTALL += "linux-firmware"
 IMAGE_INSTALL += "bluez5"

--- a/templates/default/template.conf
+++ b/templates/default/template.conf
@@ -4,7 +4,7 @@ EXTRA_BBMASK .= "|meta-overc/meta-cube/recipes-core/busybox"
 #EXTRA_BBMASK .= "|meta-openembedded/meta-systemd/oe-core/recipes-core/busybox"
 
 # Specific versions for Luci
-PREFERRED_VERSION_hostapd = "2.4"
+PREFERRED_VERSION_hostapd = "2.6"
 PREFERRED_VERSION_lua = "5.1.5"
 #PREFERRED_VERSION_iw = "3.15"
 


### PR DESCRIPTION
The oe-core master branch in WindRiver-OpenSourceLabs hasn't been updated recently.

These fixes to meta-gateway will resolve build failures that occur when using the latest oe-core from OpenEmbedded.