### PR TITLE
gw-base:fix hostname storage issue

### DIFF
--- a/recipes-core-luci/gw-base/files/firstboot.service
+++ b/recipes-core-luci/gw-base/files/firstboot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Firstboot for GateWay
-Before=sysinit.target shutdown.target systemd-update-done.service
+Before=sysinit.target shutdown.target systemd-update-done.service boot-stage4.service
 After=systemd-udevd.service run-postinsts.service systemd-remount-fs.service systemd-tmpfiles-setup.service tmp.mount
 DefaultDependencies=no
 

--- a/recipes-core-luci/gw-base/files/sbin/firstboot
+++ b/recipes-core-luci/gw-base/files/sbin/firstboot
@@ -17,6 +17,13 @@ else
 fi
 
 # Set hostname from ethernet MAC address/kernel UUID/date random
+if [ ! -e /etc/config/system ]; then
+	cat <<EOF > /etc/config/system
+config system
+	option hostname 'PulsarGateway'
+EOF
+fi
+
 ifconfig eth0 up
 hostname_id=$(cat /sys/class/net/eth0/address 2>&- | sed 's/://g')
 [ -z "${hostname_id}" ] && {

--- a/recipes-core-luci/gw-base/gw-base_1.0.bb
+++ b/recipes-core-luci/gw-base/gw-base_1.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WR_EXTRA_LIC_DIR}/windriver;md5=eb3421117285c0b7ccb
 
 PR = "r1"
 
-RDEPENDS_${PN} = "btrfs-tools"
+RDEPENDS_${PN} = "btrfs-tools gw-boot"
 
 SRC_URI += " \
     file://firstboot.service \


### PR DESCRIPTION
Hostname is generated by firstboot service then save to /etc/config/system.

Create the file when there is no such file in rootfs.

Since hostname is set by boot-stage4.service after generated, add dependence
for gw-base & firstboot.service.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>